### PR TITLE
[SECURITY] Fix Insecure Unserialize

### DIFF
--- a/Classes/class.tx_pagepath_api.php
+++ b/Classes/class.tx_pagepath_api.php
@@ -34,7 +34,7 @@ class tx_pagepath_api
         }
         $siteUrl = self::getSiteUrl($pageId);
         if ($siteUrl) {
-            $url = $siteUrl . 'index.php?eID=pagepath&data=' . base64_encode(serialize($data));
+            $url = $siteUrl . 'index.php?eID=pagepath&data=' . base64_encode(json_encode($data));
             // Send TYPO3 cookies as this may affect path generation
             $headers = array(
                 'Cookie: fe_typo_user=' . $_COOKIE['fe_typo_user']

--- a/Classes/class.tx_pagepath_resolver.php
+++ b/Classes/class.tx_pagepath_resolver.php
@@ -44,7 +44,7 @@ class tx_pagepath_resolver
      */
     public function __construct()
     {
-        $params = unserialize(base64_decode(GeneralUtility::_GP('data')));
+        $params = json_decode(base64_decode(GeneralUtility::_GP('data')), true);
         if (is_array($params)) {
             $this->pageId = $params['id'];
             $this->parameters = $params['parameters'];


### PR DESCRIPTION
Use json instead of serialize, which also works here for us and is not
susceptible for malicious user input and is also faster.
