### PR TITLE
Rename composer.js dependency typo3/cms-core to typo3/cms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         ]
     },
     "require": {
-        "typo3/cms-core": "^7.6 || ^8.6"
+        "typo3/cms": "^7.6 || ^8.6"
     },
     "require-dev": {
         "namelesscoder/typo3-repository-client": "^1.2.0"


### PR DESCRIPTION
Hi,

I'm working on a composer based project running TYPO3 8.7.10.
Unfortunately I couldn't install your EXT (version 1.1.6) with composer.
On https://packagist.org/packages/typo3/cms#8.7.10 (replaces typo3/cms-core) you can see that the naming  changed apparently from "typo3/cms-core" to "typo3/cms".

Kind regards
Kevin
