### PR TITLE
[BUGFIX] - php 7.0 compatibility fix

### DIFF
--- a/Classes/FrontendRequest.php
+++ b/Classes/FrontendRequest.php
@@ -13,17 +13,17 @@ class FrontendRequest
 
     protected $url = '';
 
-    public function addHeader(string $key, string $value): void
+    public function addHeader(string $key, string $value)
     {
         $this->headers[$key] = $value;
     }
 
-    public function setVerify(bool $verify): void
+    public function setVerify(bool $verify)
     {
         $this->verify = $verify;
     }
 
-    public function setUrl(string $url): void
+    public function setUrl(string $url)
     {
         $this->url = $url;
     }

--- a/Classes/Resolver.php
+++ b/Classes/Resolver.php
@@ -57,7 +57,7 @@ class Resolver
         return $url;
     }
 
-    protected function createTSFE(int $pageId): void
+    protected function createTSFE(int $pageId)
     {
         $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class, $GLOBALS['TYPO3_CONF_VARS'], $pageId, '');
 


### PR DESCRIPTION
Return type `void` for method is not compatible with php 7.0 version